### PR TITLE
Add `dev` integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem "rake"
+gem "observr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    observr (1.0.5)
+    rake (13.0.6)
+
+PLATFORMS
+  arm64-darwin-21
+
+DEPENDENCIES
+  observr
+  rake
+
+BUNDLED WITH
+   2.3.15

--- a/dev.yml
+++ b/dev.yml
@@ -22,7 +22,7 @@ commands:
     run: bundle exec rake
   watch:
     desc: Watch the path to enlightenment (run the koans whenever you edit them)
-    run: bundle exec observr ./koans/koans.watchr
+    run: bundle exec rake && bundle exec observr ./koans/koans.watchr
 
 open:
   koans: http://rubykoans.com/ # No, it doesn't support HTTPS...

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,28 @@
+name: ruby-koans
+
+type: ruby
+
+up:
+  - ruby: 3.1.2
+  - bundler
+  - custom:
+      name: Generate Koans
+      met?: test -d koans
+      meet: bundle exec rake gen
+
+commands:
+  regenerate:
+    desc: Renegerate koans directory
+    run: bundle exec rake regen
+  delete:
+    desc: Delete the koans directory and all its contents
+    run: bundle exec rake clobber_koans
+  test:
+    desc: Take the path to enlightenment (run the koans)
+    run: bundle exec rake
+  watch:
+    desc: Watch the path to enlightenment (run the koans whenever you edit them)
+    run: bundle exec observr ./koans/koans.watchr
+
+open:
+  koans: http://rubykoans.com/ # No, it doesn't support HTTPS...


### PR DESCRIPTION
This allows Shopify devs to get up and running seamlessly.